### PR TITLE
Add API and Examples to the docs

### DIFF
--- a/docs/docs/docs/api.md
+++ b/docs/docs/docs/api.md
@@ -1,0 +1,46 @@
+# Python
+
+## `chaincrafter.chains`
+- `Chain`
+    - `run(chat_model: ChatModel, starting_input_vars: dict) -> [Message]`: Runs the chain given a `ChatModel` and a set of starting input variables. 
+    - `async_run(chat_model: ChatModel, starting_input_vars: dict) -> [Message]`: Runs the chain asynchronously using `asyncio`, see [Async](./async.md)
+- `Message`, a typed dictionary (based on the response from OpenAI API)
+
+## `chaincrafter.experiments`
+- `Experiment`
+    - `Experiment(chain: Chain, **model_params)`
+    - `set_chain_starting_input_vars(starting_input_vars: dict)`
+    - `prepare()`
+    - `run(runs: int = 1)`
+    - `to_csv()`
+    - `to_pandas_df()`
+    - `to_json()`
+    - `visualize()`
+- `OpenAiChatExperiment(Experiment)` 
+
+## `chaincrafter.models`
+- `ChatModel`
+    - `ChatModel(temperature: float, model_name: str)`
+    - `complete(messages: [dict]) -> str`
+    - `show_usage()`
+- `MockChat(ChatModel)`
+    - `MockChat(temperature: float, model_name: str)`
+    - `mock_responses(messages: [dict])`
+    - `complete(messages: [dict])`
+- `OpenAiChat(ChatModel)`
+    - `OpenAiChat(temperature: float, model_name: str, top_p: float, n: int, stream: bool, stop: [str], max_tokens: int, presence_penalty: float, frequency_penalty: float, logit_bias: dict)`: same API as [OpenAI API](https://platform.openai.com/docs/api-reference/chat/create)
+    - `complete(messages: [dict])`
+    - `show_usage()`
+
+## `chaincrafter.prompts`
+- `Prompt`
+    - `Prompt(fmt_str: str, prompt_modifiers: [Callable], **input_vars_transformers: [dict[str, Callable]])`
+    - `build(**input_vars: dict) -> str`
+- `response_format_list(example_item_text: str) -> Callable[[str], str]`
+- `response_style(style_of: str) -> str`
+- `response_length(short_or_long: str = "short", answer_or_paragraph: str = "sentence") -> str`
+- `extract_items_from_list(response: str) -> [str]`
+
+# JavaScript/TypeScript
+
+*work in progress*

--- a/docs/docs/docs/examples.md
+++ b/docs/docs/docs/examples.md
@@ -1,0 +1,30 @@
+# Python
+
+*[Code Reviewer Async](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/code_reviewer_async.py)*:
+An example of using [the async API](./async.md) to run a chain of messages asynchronously. It uses a `git diff` as the material for a code review.
+The results are a code review from a software engineer, a pull request description, and a description that could be used as a git commit message.
+
+*[Comparing Code Models](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/comparing_code_models.py)*:
+This example uses a prompt with the GPT-3.5 and GPT-4 models that will generate suggestions for code improvements and then apply the suggestions to the code.
+
+*[Describe Topic Experiment](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/describe_topic_experiment.py)*:
+Uses an [experiment](./experiments.md) to compare the responses from GPT-3.5 and GPT-4 for a chain of prompts that asks
+
+*[Hello World](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/hello_world.py)*:
+Chain of two prompts; the first asks for the capital of a country, the second asks for the city's population.
+
+*[Hello World Async](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/hello_world_async.py)*:
+Same as *Hello World*, however it uses [the async API](./async.md) to run two chains asynchronously. It asks for the capital cities of two countries and then asks for the population of each.
+
+*[Hello World Experiment](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/hello_world_experiment.py)*:
+Same as *Hello World*, however it uses an [experiment](./experiments.md) to run the chain with two different models and different model parameters. Also prints out the output in different formats (CSV, JSON, Pandas DataFrame).
+
+*[Interesting Facts](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/interesting_facts.py)*:
+Demonstrates using [methods to transform and modify prompts and to extract data from responses](./api.md). It will prompt for a list of facts about a topic, which are formatted in a particular way, and then it extracts the first fact and passes it along to the next prompt. The response styles are changed between the prompts, the response length is added to the prompt, and the list format to be used is also part of the prompt.
+
+*[Math](https://github.com/rudolfolah/chaincrafter/blob/main/python/examples/math.py)*:
+An example based on the math example from MiniChain. It uses few-shot training prompt to include math questions and the code that solves them. The prompt asks for the Python code to solve the given math problem and then runs the code to produce the answer.
+
+# JavaScript/TypeScript
+
+*work in progress*

--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -5,6 +5,8 @@ nav:
   - integrations.md
   - experiments.md
   - async.md
+  - 'Examples': examples.md
+  - 'API': api.md
 plugins:
   - mermaid2
   - include-markdown

--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: chaincrafter
 nav:
+  - Docs: index.md
   - GitHub: 'https://github.com/rudolfolah/chaincrafter'
   - integrations.md
   - experiments.md


### PR DESCRIPTION
- API reference for Python `chaincrafter` modules
- Examples are described and linked to their source code in the repo